### PR TITLE
Update to testing, addition of convertor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ The type can be any one of:\
 
 For more examples, please view the swagger documentation.
 
+# Testing
+Tests can be run on the same machine where it is deployed.\
+They can be run by moving into the  ```/tests/``` dir and running ```pytest tests_.py``` \
+This will run the tests on the machine and return response values for either passing or failing to run.
+
 # Contribution
 Please contact the maintainer of this repository.
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,25 @@ The type can be any one of:\
 For more examples, please view the swagger documentation.
 
 # Testing
-Tests can be run on the same machine where it is deployed.\
+The reporting service offers two ways to test it out, using the suite of tests written in pytest, or using converter \
+scripts that are present [here](https://github.com/openagri-eu/OCSM/tree/main/converters).
+
+<h2>Pytest</h2>
+Pytest can be run on the same machine the service has been deployed to.\
 They can be run by moving into the  ```/tests/``` dir and running ```pytest tests_.py``` \
-This will run the tests on the machine and return response values for either passing or failing to run.
+This will run the tests and return success values for each api in the terminal.
+
+<h3>These tests will NOT result in generated .pdf files.</h3>
+
+<h2>Script</h2>
+There is also the ```far_calendar_to_jsonld.py``` script, that can be run from the ```/tests/``` dir as well, with the following command: \
+```python farm_calendar_to_jsonld.py ./example/datasets/example_farm_calendar.json```. \
+This command will then prompt the user for input. \
+Any generated reports via this script will be placed inside the /tests/example/reports/ dir. \
+The example raw dataset is transformed into the ```example_farm_calendar_AIM.jsonld``` file, that is OCSM compliant. \
+This file is then used for generating reports, that can be seen in the ```/reports/``` dir.
+
+<h3>These tests WILL result in generated .pdf files.</h3>
 
 # Contribution
 Please contact the maintainer of this repository.

--- a/README.md
+++ b/README.md
@@ -192,18 +192,27 @@ scripts that are present [here](https://github.com/openagri-eu/OCSM/tree/main/co
 
 <h2>Pytest</h2>
 Pytest can be run on the same machine the service has been deployed to.\
-They can be run by moving into the  ```/tests/``` dir and running ```pytest tests_.py``` \
+They can be run by moving into the tests dir and running:
+
+```
+pytest tests_.py 
+```
+
 This will run the tests and return success values for each api in the terminal.
 
 <h3>These tests will NOT result in generated .pdf files.</h3>
 
 <h2>Script</h2>
-There is also the ```far_calendar_to_jsonld.py``` script, that can be run from the ```/tests/``` dir as well, with the following command: \
-```python farm_calendar_to_jsonld.py ./example/datasets/example_farm_calendar.json```. \
+There is also the farm_calendar_to_jsonld.py script, that can be run from the <strong>tests</strong> dir as well, with the following command:
+
+```
+python farm_calendar_to_jsonld.py ./example/datasets/example_farm_calendar.json
+```
+
 This command will then prompt the user for input. \
 Any generated reports via this script will be placed inside the /tests/example/reports/ dir. \
-The example raw dataset is transformed into the ```example_farm_calendar_AIM.jsonld``` file, that is OCSM compliant. \
-This file is then used for generating reports, that can be seen in the ```/reports/``` dir.
+The example raw dataset is transformed into the example_farm_calendar_AIM.jsonld file, that is OCSM compliant. \
+This file is then used for generating reports, that can be seen in the reports dir.
 
 <h3>These tests WILL result in generated .pdf files.</h3>
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The reporting service offers two ways to test it out, using the suite of tests w
 scripts that are present [here](https://github.com/openagri-eu/OCSM/tree/main/converters).
 
 <h2>Pytest</h2>
-Pytest can be run on the same machine the service has been deployed to, they can be run by moving into the tests dir and running:
+Pytest can be run on the same machine the service has been deployed to by moving into the tests dir and running:
 
 ```
 pytest tests_.py 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The reporting service offers two ways to test it out, using the suite of tests w
 scripts that are present [here](https://github.com/openagri-eu/OCSM/tree/main/converters).
 
 <h2>Pytest</h2>
-Pytest can be run on the same machine the service has been deployed to.\
+Pytest can be run on the same machine the service has been deployed to. \
 They can be run by moving into the tests dir and running:
 
 ```
@@ -203,7 +203,7 @@ This will run the tests and return success values for each api in the terminal.
 <h3>These tests will NOT result in generated .pdf files.</h3>
 
 <h2>Script</h2>
-There is also the farm_calendar_to_jsonld.py script, that can be run from the <strong>tests</strong> dir as well, with the following command:
+There is also the farm_calendar_to_jsonld.py script, that can be run from the tests dir as well, with the following command:
 
 ```
 python farm_calendar_to_jsonld.py ./example/datasets/example_farm_calendar.json

--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ The reporting service offers two ways to test it out, using the suite of tests w
 scripts that are present [here](https://github.com/openagri-eu/OCSM/tree/main/converters).
 
 <h2>Pytest</h2>
-Pytest can be run on the same machine the service has been deployed to. \
-They can be run by moving into the tests dir and running:
+Pytest can be run on the same machine the service has been deployed to, they can be run by moving into the tests dir and running:
 
 ```
 pytest tests_.py 

--- a/tests/example/datasets/example_farm_calendar.json
+++ b/tests/example/datasets/example_farm_calendar.json
@@ -1,0 +1,625 @@
+{
+  "pesticides_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-02-07",
+      "comercialDrugName": "BORDELESA 20 WP",
+      "dose": 1176.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Bordeaux mixture",
+      "target": "Powdery mildew",
+      "remarks": "This was a preventive application. No prior symptoms detected."
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-03-16",
+      "comercialDrugName": "KOCIDE 2000 35 WG",
+      "dose": 588.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Copper hydroxide",
+      "target": "Powdery mildew",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-04-08",
+      "comercialDrugName": "COMET 20 EC",
+      "dose": 470.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Pyraclostrobin",
+      "target": "Powdery mildew",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-04-08",
+      "comercialDrugName": "TRIMANOC 75 WG",
+      "dose": 200.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Mancozeb",
+      "target": "Powdery mildew",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-04-28",
+      "comercialDrugName": "SYLLIT 544 SC",
+      "dose": 150.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Dodine",
+      "target": "Powdery mildew",
+      "remarks": "και KSAR"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-05-11",
+      "comercialDrugName": "LAINCOIL",
+      "dose": 100.0,
+      "unit": "ml/ha",
+      "activeSubstance": null,
+      "target": "",
+      "remarks": "ACTELIC ΚΑΙ ΔΙΑΦΥΛΛΙΚΑ"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-05-19",
+      "comercialDrugName": "ADMIRAL 10 EC",
+      "dose": 30.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Pyriproxyfen",
+      "target": "Basin or black olive scab",
+      "remarks": "και ΔΙΑΦΥΛΛΙΚΑ."
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-05-19",
+      "comercialDrugName": "DECIS 2,5 EC",
+      "dose": 100.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Deltamethrin",
+      "target": "Prays Oleae",
+      "remarks": "και ΔΙΑΦΥΛΛΙΚΑ."
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-06-01",
+      "comercialDrugName": null,
+      "dose": 100.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Pirimiphos-methyl",
+      "target": "",
+      "remarks": "Ο παραγωγός ψέκασε με το σκεύασμα Actellic 50 EC (δραστική ουσία 50% pirimiphos-methyl)"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-06-14",
+      "comercialDrugName": "KARATE with Zeon technology 10 CS",
+      "dose": 20.0,
+      "unit": "ml/ha",
+      "activeSubstance": "lambda-cyhalothrin",
+      "target": "Prays Oleae",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-08-29",
+      "comercialDrugName": "JADE 40 WG",
+      "dose": 320.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Copper hydroxide",
+      "target": "Powdery mildew",
+      "remarks": "Intervention by advice. It also acts against gliosporium"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-11-18",
+      "comercialDrugName": "CUPROS 50 WP",
+      "dose": 250.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Copper hydroxide",
+      "target": "Powdery mildew",
+      "remarks": "Intervention by advice. It also acts against gliosporium"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-12-13",
+      "comercialDrugName": "AQQUOS 20 WP",
+      "dose": 500.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Bordeaux mixture",
+      "target": "Powdery mildew",
+      "remarks": "Intervention by advice. It also acts against gliosporium"
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-02-08",
+      "comercialDrugName": "BORDELESA 20 WP",
+      "dose": 1100.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Bordeaux mixture",
+      "target": "Powdery mildew",
+      "remarks": "This was a preventive application. No prior symptoms detected."
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-03-26",
+      "comercialDrugName": "KOCIDE 2000 35 WG",
+      "dose": 550.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Copper hydroxide",
+      "target": "Powdery mildew",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-04-12",
+      "comercialDrugName": "COMET 20 EC",
+      "dose": 490.0,
+      "unit": "ml/ha",
+      "activeSubstance": "Pyraclostrobin",
+      "target": "Powdery mildew",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-12-15",
+      "comercialDrugName": "AQQUOS 20 WP",
+      "dose": 510.0,
+      "unit": "gr/ha",
+      "activeSubstance": "Bordeaux mixture",
+      "target": "Powdery mildew",
+      "remarks": "Intervention by advice. It also acts against gliosporium"
+    }
+
+  ],
+  "harvest_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-09-26",
+      "quantity": 6970,
+      "unit": "kg/Ha",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-09-29",
+      "quantity": 6620,
+      "unit": "kg/Ha",
+      "remarks": null
+    },
+     {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-10-02",
+      "quantity": 7200,
+      "unit": "kg/Ha",
+      "remarks": null
+    }
+  ],
+  "irrigation_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-07-23",
+      "startDateTime": "2023-07-23 08:45:00",
+      "endDateTime": "2023-07-23 22:00:00",
+      "waterQuantity": "420",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": "Intervention by advice",
+      "irrigHour": "13.25"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-07-30",
+      "startDateTime": "2023-07-30 07:45:00",
+      "endDateTime": "2023-07-30 21:00:00",
+      "waterQuantity": "420",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "13.25"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-08-06",
+      "startDateTime": "2023-08-06 08:00:00",
+      "endDateTime": "2023-08-06 15:00:00",
+      "waterQuantity": "220",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "7.0"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-08-10",
+      "startDateTime": "2023-08-10 11:30:00",
+      "endDateTime": "2023-08-10 15:00:00",
+      "waterQuantity": "110",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "3.5"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-08-16",
+      "startDateTime": "2023-08-16 09:00:00",
+      "endDateTime": "2023-08-16 17:00:00",
+      "waterQuantity": "25",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": "Intervention by advice",
+      "irrigHour": "8"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-08-30",
+      "startDateTime": "2023-08-30 06:00:00",
+      "endDateTime": "2023-08-30 14:00:00",
+      "waterQuantity": "25",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "8.0"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-09-13",
+      "startDateTime": "2023-09-13 09:00:00",
+      "endDateTime": "2023-09-13 17:00:00",
+      "waterQuantity": "25",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": "Intervention by advice",
+      "irrigHour": "8.0"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-09-20",
+      "startDateTime": "2023-09-20 10:00:00",
+      "endDateTime": "2023-09-20 18:00:00",
+      "waterQuantity": "25",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "8.0"
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-07-20",
+      "startDateTime": "2023-07-20 08:45:00",
+      "endDateTime": "2023-07-20 22:00:00",
+      "waterQuantity": "400",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": "Intervention by advice",
+      "irrigHour": "13.25"
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-07-29",
+      "startDateTime": "2023-07-29 07:45:00",
+      "endDateTime": "2023-07-29 21:00:00",
+      "waterQuantity": "400",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "13.25"
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-08-08",
+      "startDateTime": "2023-08-08 08:00:00",
+      "endDateTime": "2023-08-08 15:00:00",
+      "waterQuantity": "230",
+      "unit": "m3/Ha",
+      "irrigationSystem": "Micro sprinklers",
+      "remarks": null,
+      "irrigHour": "7.0"
+    }
+  ],
+  "phaenological_stages_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Μεταχρωματισμός καρπού (γυάλισμα)",
+      "from": "2021-08-19",
+      "to": "2023-01-10"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Εισαγωγή στο λήθαργο-Οφθαλμός σε αναστολή βλάστησης",
+      "from": "2023-01-11",
+      "to": "2023-02-13"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Κυρίως λήθαργος",
+      "from": "2023-02-14",
+      "to": "2023-03-20"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Διαφοροποίηση οφθαλμών – Διακοπή του λήθαργου",
+      "from": "2023-03-21",
+      "to": "2023-04-04"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Έκπτυξη οφθαλμών",
+      "from": "2023-04-05",
+      "to": "2023-04-12"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Εμφάνιση των πρώτων φύλλων- Νεαρή βλάστηση",
+      "from": "2023-04-13",
+      "to": "2023-04-27"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Βλάστηση φύλλων- Διόγκωση ανθοφόρου οφθαλμού",
+      "from": "2023-04-28",
+      "to": "2023-05-05"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Βλάστηση με κλειστά άνθη",
+      "from": "2023-05-06",
+      "to": "2023-05-17"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Βλάστηση με διαχωρισμό κλειστού άνθους- Εμφάνιση πετάλων",
+      "from": "2023-05-18",
+      "to": "2023-05-23"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Έναρξη άνθησης",
+      "from": "2023-05-24",
+      "to": "2023-05-29"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Πλήρης άνθηση",
+      "from": "2023-05-30",
+      "to": "2023-06-05"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Πτώση πετάλων",
+      "from": "2023-05-30",
+      "to": "2023-06-05"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Πρώτη ανάπτυξη καρπού(ταχεία)- Διόγκωση καρπού",
+      "from": "2023-06-06",
+      "to": "2023-06-21"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Δεύτερη ανάπτυξη καρπού (βραδεία)",
+      "from": "2023-06-22",
+      "to": "2023-07-06"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Σκλήρυνση πυρήνα",
+      "from": "2023-07-07",
+      "to": "2023-07-28"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Λίγο πριν τον μεταχρωματισμό (γυάλισμα)",
+      "from": "2023-07-29",
+      "to": "2023-08-09"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "crop": " Olives",
+      "variety": "Chalkidikis",
+      "stage": "Μεταχρωματισμός καρπού (γυάλισμα)",
+      "from": "2023-08-10",
+      "to": "2023-05-07"
+    }
+  ],
+  "fertilizations_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-02-26",
+      "fertilization_description": "Basal Fertlization",
+      "fertilization_application_method": "Dispration",
+      "dose": "4",
+      "unit": "kg",
+      "referenceDose": "per plant",
+      "is_organic": false,
+      "product_name": "ENTEC 20-8-10(+2Mgo+3S)",
+      "remarks": "The fertilisation type and dose derived after the soil analysis with id: 0123"
+    },
+    {
+      "parcelUniqueIdentifier": 123001,
+      "date": "2023-06-14",
+      "fertilization_description": "άλλη μέθοδος",
+      "fertilization_application_method": "liquid foliar fertilizer",
+      "dose": "1.000",
+      "unit": "lt",
+      "referenceDose": "Hectar",
+      "is_organic": true,
+      "product_name": "AMINO 16",
+      "remarks": null
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-02-29",
+      "fertilization_description": "Basal Fertlization",
+      "fertilization_application_method": "Dispration",
+      "dose": "5",
+      "unit": "kg",
+      "referenceDose": "per plant",
+      "is_organic": false,
+      "product_name": "ENTEC 20-8-10(+2Mgo+3S)",
+      "remarks": "The fertilisation type and dose derived after the soil analysis with id: 0123"
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+      "date": "2023-06-24",
+      "fertilization_description": "άλλη μέθοδος",
+      "fertilization_application_method": "liquid foliar fertilizer",
+      "dose": "1.5",
+      "unit": "lt",
+      "referenceDose": "Hectar",
+      "is_organic": true,
+      "product_name": "AMINO 16",
+      "remarks": null
+    }
+  ],
+  "parcel_related_data": [
+    {
+      "parcelUniqueIdentifier": 123001,
+      "description": "Olive grove A",
+
+      "validFrom":"2023-01-01T00:00:00",
+      "validTo":"2023-12-31T23:59:59",
+      "inRegion":"Attica/Greece",
+      "hasToponym":"Oropos",
+      "parcel_area":3.0,
+      "parcel_area_unit": "Ha",
+      "isNitroAarea": 1,
+      "isNatura2000Area": 0,
+      "isPDOPGIArea":0,
+      "isIrrigated":1,
+      "isCultivatedInLevels":0,
+      "isGroundSlope":1,
+      "depiction":"http://example.org/satelite_image/picture1.jpg",
+
+      "category": "orchard",
+      "crop_type": "Olea europea",
+      "crop_type_agrovoc":"http://aims.fao.org/aos/agrovoc/c_12926",
+      "crop_type_variety": "Chalkidikis",
+      "crop_type_product": "Table olives",
+
+      "soil_pH_Value": 7.8,
+      "soil_salinity_value": 0.64,
+      "soil_salinity_unit":"dS/m",
+
+      "soil_organic_content_value": 4,
+      "soil_organic_content_unit": "%",
+
+      "irrigation_system": "micro sprinkler",
+      "irrigation_supply_rate": 0.12,
+      "irrigation_supply_rate_unit": "m3/hour",
+
+      "gis": [
+        {
+          "wkt": "POLYGON(((23.7291120943909 38.311867323636875,23.72834175131419 38.309300443635294, 23.729491989607823 38.309118274505494, 23.7302095694605 38.311676880822006, 23.7291120943909, 38.311867323636875)))",
+          "computed_hectars": 2.93,
+          "longitude": 23.72834175131419,
+          "latitude": 38.309300443635294
+        }
+      ]
+    },
+    {
+      "parcelUniqueIdentifier": 123002,
+       "description": "Olive grove B",
+
+      "validFrom":"2023-01-01T00:00:00",
+      "validTo":"2023-12-31T23:59:59",
+      "inRegion":"Attica/Greece",
+      "hasToponym":"Oropos",
+      "parcel_area":6.3,
+      "parcel_area_unit": "Ha",
+      "isNitroAarea": 1,
+      "isNatura2000Area": 0,
+      "isPDOPGIArea":0,
+      "isIrrigated":1,
+      "isCultivatedInLevels":0,
+      "isGroundSlope":1,
+      "depiction":"http://example.org/satelite_image/picture1.jpg",
+
+      "category": "orchard",
+      "crop_type": "Olea europea",
+      "crop_type_agrovoc":"http://aims.fao.org/aos/agrovoc/c_12926",
+      "crop_type_variety": "Chalkidikis",
+      "crop_type_product": "Table olives",
+
+      "soil_pH_Value": 6.8,
+      "soil_salinity_value": 0.74,
+      "soil_salinity_unit":"dS/m",
+
+      "soil_organic_content_value": 5,
+      "soil_organic_content_unit": "%",
+
+      "irrigation_system": "micro sprinkler",
+      "irrigation_supply_rate": 0.12,
+      "irrigation_supply_rate_unit": "m3/hour",
+
+      "gis": [
+        {
+          "wkt": "POLYGON(((23.733335084908617 38.31118631434748,   23.732465315464964 38.308413730027695,  23.732465315464964 38.308413730027695,  23.734346191887084 38.3079359817161, 23.735042007441933 38.30957396282503, 23.735476892164286 38.31025644403522,  23.735966137476566 38.31077683164247, 23.733335084908617 38.31118631434748)))",
+          "computed_hectars": 6.3,
+          "longitude": 23.732465315464964,
+          "latitude": 38.308413730027695
+        }
+      ]
+    }
+  ],
+  "farm_related_data":[{
+      "farmUniqueIdentifier": 123000,
+      "farmName": "The OpenAgri prototype Farm",
+      "description": "A farm in Attica Greece with two parcels cultivating table olives",
+      "farmAdministratorName" : "Marinos Antypas",
+      "farmContactPerson": "Marinos Antypas",
+      "telephone":"+30-08101907",
+      "vatID":"xyz-abc-1234",
+      "adminUnitL1": "Greece",
+      "adminUnitL2": "Attica",
+      "addressArea": "no address",
+      "municipality":"Oropos",
+      "community":"",
+      "locatorName":"Killeler",
+      "totalFarmArea": 20,
+      "totalFarmAreaUnit": "Ha",
+      "farm_parcel_ids": [123001, 123002],
+      "gis": [
+        {
+          "wkt": "POLYGON(((23.7291120943909 38.311867323636875, 23.72834175131419 38.309300443635294, 23.729491989607823 38.309118274505494, 23.7302095694605 38.311676880822006,23.7291120943909 38.311867323636875)))",
+          "computed_hectars": 20.21,
+          "longitude": 23.72834175131419, 
+          "latitude": 38.309300443635294
+        }
+      ]
+  }]
+}

--- a/tests/example/datasets/example_farm_calendar_AIM.jsonld
+++ b/tests/example/datasets/example_farm_calendar_AIM.jsonld
@@ -1,0 +1,784 @@
+{
+    "@context": [
+        "https://w3id.org/ocsm/main-context.jsonld"
+    ],
+    "@graph": [
+        {
+            "@id": "urn:openagri:farm:32841138-1d60-4c9c-86c3-2275cb1fe4fd",
+            "@type": "Farm",
+            "name": "The OpenAgri prototype Farm",
+            "description": "A farm in Attica Greece with two parcels cultivating table olives",
+            "hasAdministrator": "Marinos Antypas",
+            "contactPerson": {
+                "@id": "urn:openagri:contact:5e763260-eb0e-49c3-b791-b177f5368e31",
+                "@type": "Person",
+                "firstname": "Marinos Antypas",
+                "lastname": "Marinos Antypas"
+            },
+            "telephone": "+30-08101907",
+            "vatID": "xyz-abc-1234",
+            "address": {
+                "@id": "urn:openagri:address:35c62721-ef46-44b1-ae38-f1dfc90d07bc",
+                "@type": "Address",
+                "adminUnitL1": "Greece",
+                "adminUnitL2": "Attica",
+                "addressArea": "no address",
+                "municipality": "Oropos",
+                "community": "",
+                "locatorName": "Killeler"
+            },
+            "area": 200000,
+            "hasAgriParcel": [
+                {
+                    "@id": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+                    "@type": "Vineyard",
+                    "identifier": 123001,
+                    "description": "Olive grove A",
+                    "category": "orchard",
+                    "validFrom": "2023-01-01T00:00:00",
+                    "validTo": "2023-12-31T23:59:59",
+                    "inRegion": "Attica/Greece",
+                    "hasToponym": "Oropos",
+                    "area": 30000.0,
+                    "isNitroAarea": 1,
+                    "isNatura2000Area": 0,
+                    "isPDOPGIArea": 0,
+                    "isIrrigated": 1,
+                    "isCultivatedInLevels": 0,
+                    "isGroundSlope": 1,
+                    "depiction": "http://example.org/satelite_image/picture1.jpg",
+                    "hasGeometry": {
+                        "@id": "urn:openagri:parcel:geo:866b3f52-ca0e-4599-aea4-0327ac7d0800",
+                        "@type": "Polygon",
+                        "asWKT": "POLYGON(((23.7291120943909 38.311867323636875,23.72834175131419 38.309300443635294, 23.729491989607823 38.309118274505494, 23.7302095694605 38.311676880822006, 23.7291120943909, 38.311867323636875)))"
+                    },
+                    "location": {
+                        "@id": "urn:openagri:parcel:point:a365d667-5933-4f78-a85b-90e667fc500d",
+                        "@type": "Point",
+                        "lat": 38.309300443635294,
+                        "long": 23.72834175131419
+                    },
+                    "usesIrrigationSystem": {
+                        "@id": "urn:openagri:parcel:irrigation:4a83dbf0-bef8-4a60-b159-bc7f036c81e3",
+                        "@type": "IrrigationSystem",
+                        "name": "micro sprinkler"
+                    },
+                    "hasIrrigationFlow": 0.12
+                },
+                {
+                    "@id": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4",
+                    "@type": "Vineyard",
+                    "identifier": 123002,
+                    "description": "Olive grove B",
+                    "category": "orchard",
+                    "validFrom": "2023-01-01T00:00:00",
+                    "validTo": "2023-12-31T23:59:59",
+                    "inRegion": "Attica/Greece",
+                    "hasToponym": "Oropos",
+                    "area": 63000.0,
+                    "isNitroAarea": 1,
+                    "isNatura2000Area": 0,
+                    "isPDOPGIArea": 0,
+                    "isIrrigated": 1,
+                    "isCultivatedInLevels": 0,
+                    "isGroundSlope": 1,
+                    "depiction": "http://example.org/satelite_image/picture1.jpg",
+                    "hasGeometry": {
+                        "@id": "urn:openagri:parcel:geo:681c7523-c707-47ac-a5db-96874f54d2ef",
+                        "@type": "Polygon",
+                        "asWKT": "POLYGON(((23.733335084908617 38.31118631434748,   23.732465315464964 38.308413730027695,  23.732465315464964 38.308413730027695,  23.734346191887084 38.3079359817161, 23.735042007441933 38.30957396282503, 23.735476892164286 38.31025644403522,  23.735966137476566 38.31077683164247, 23.733335084908617 38.31118631434748)))"
+                    },
+                    "location": {
+                        "@id": "urn:openagri:parcel:point:7073a07d-faa6-4a8c-829c-df3f247b25a9",
+                        "@type": "Point",
+                        "lat": 38.308413730027695,
+                        "long": 23.732465315464964
+                    },
+                    "usesIrrigationSystem": {
+                        "@id": "urn:openagri:parcel:irrigation:ba217b5d-2c79-434d-92ed-47cd7019b58d",
+                        "@type": "IrrigationSystem",
+                        "name": "micro sprinkler"
+                    },
+                    "hasIrrigationFlow": 0.12
+                }
+            ]
+        },
+        {
+            "@id": "urn:openagri:irrigation:f257fb12-2e52-486b-917d-9d0d384bf95a",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-07-23 08:45:00",
+            "endedAt": "2023-07-23 22:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:f1afa94a-a78e-48f7-afeb-a6a1a77e386d",
+                "@type": "QuantityValue",
+                "numericValue": "420",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:d55f2021-49b9-4b1b-8695-7d3b580171b2",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:41753bf4-de5c-492e-a331-5fb7e80ec30f",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-07-30 07:45:00",
+            "endedAt": "2023-07-30 21:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:99aef08d-9b9c-451b-8b6e-ab76ceb3b23e",
+                "@type": "QuantityValue",
+                "numericValue": "420",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:5bcaca1f-2c05-4cff-ab18-f0bcb17faf8a",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:d3d7f295-d5c8-4757-a1dd-1097a33befb5",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-08-06 08:00:00",
+            "endedAt": "2023-08-06 15:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:765702ac-0809-48fa-b5b4-e9537fd46367",
+                "@type": "QuantityValue",
+                "numericValue": "220",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:4497bd13-73bc-4429-a8e5-ab947e507937",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:7ba13f7e-7dcc-4145-87f2-68b1ea54195e",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-08-10 11:30:00",
+            "endedAt": "2023-08-10 15:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:c25aa303-b78a-4b05-8b7d-051269d8faa1",
+                "@type": "QuantityValue",
+                "numericValue": "110",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:0e1b7581-b4c7-4ac2-abbd-537b5b9941ea",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:1e9de897-862a-44a1-8c16-65b197f59cc4",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-08-16 09:00:00",
+            "endedAt": "2023-08-16 17:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:b8512f50-a016-4c58-8a0c-83357543ca7e",
+                "@type": "QuantityValue",
+                "numericValue": "25",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:47630f5a-cb66-4853-8419-0e5e1f26a49e",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:0179e419-6eff-4bd6-b628-d860c7685580",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-08-30 06:00:00",
+            "endedAt": "2023-08-30 14:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:452f124e-7e5a-460b-b511-143fe70658c3",
+                "@type": "QuantityValue",
+                "numericValue": "25",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:8da69aa9-9730-4a76-b318-e88e5c9724df",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:686f8987-d401-4544-867e-8d550be493eb",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-09-13 09:00:00",
+            "endedAt": "2023-09-13 17:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:3fda0a2e-b559-444c-be05-0ea6045b3008",
+                "@type": "QuantityValue",
+                "numericValue": "25",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:e1019c78-3c3d-4f83-9538-5ec501195f1b",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:3cb727ff-8e6b-4e6e-b175-31c3d5490090",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-09-20 10:00:00",
+            "endedAt": "2023-09-20 18:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:b4d3f8ed-be79-46f1-abb2-99cc0b7e7b28",
+                "@type": "QuantityValue",
+                "numericValue": "25",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:1506f9de-a3d6-45bb-86f8-f2d7731463f9",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:irrigation:d3bc855c-2bc0-4a16-b3c6-45f9fc8edb37",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-07-20 08:45:00",
+            "endedAt": "2023-07-20 22:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:da3585e8-f0e0-4a23-9b65-9461544f259b",
+                "@type": "QuantityValue",
+                "numericValue": "400",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:4f8d48d0-e70f-4410-bad7-e478026e9566",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4"
+        },
+        {
+            "@id": "urn:openagri:irrigation:9fb5af63-dfe8-4a0f-9cb2-231c85ea0a93",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-07-29 07:45:00",
+            "endedAt": "2023-07-29 21:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:e7870958-1419-4a52-add3-65095934c722",
+                "@type": "QuantityValue",
+                "numericValue": "400",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:b10d2cde-8e82-4679-85f9-73cf145996b4",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4"
+        },
+        {
+            "@id": "urn:openagri:irrigation:e93c8dcb-1e69-4589-beae-a9cc61375610",
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": "2023-08-08 08:00:00",
+            "endedAt": "2023-08-08 15:00:00",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:irrigation:amount:35ed71ca-a97e-4d47-923f-664e99eb5ee4",
+                "@type": "QuantityValue",
+                "numericValue": "230",
+                "unit": "http://qudt.org/vocab/unit/M3"
+            },
+            "usesIrrigationSystem": {
+                "@id": "urn:openagri:irrigation:system:265b3817-d388-4ae9-96f0-0b8255fdc503",
+                "@type": "IrrigationSystem",
+                "name": "Micro sprinklers",
+                "hasIrrigationType": "Micro sprinklers"
+            },
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4"
+        },
+        {
+            "@id": "urn:openagri:fertilization:23fe7b39-7023-4209-995d-279fc4f6d479",
+            "@type": "FertilizationOperation",
+            "description": "Basal Fertlization",
+            "hasTimestamp": "2023-02-26",
+            "usesFertilizer": {
+                "@id": "urn:openagri:fertilization:product:1026e355-b398-4e7f-a1a6-0fdd519e95b9",
+                "@type": "Fertilizer",
+                "hasCommercialName": "ENTEC 20-8-10(+2Mgo+3S)"
+            },
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:fertilization:amount:af4d5866-b7dc-459a-a1be-25f26be7f0ee",
+                "@type": "QuantityValue",
+                "numericValue": "4",
+                "unit": "https://w3id.org/ocsm/KiloGM-PER-PLANT"
+            },
+            "plan": {
+                "@id": "urn:openagri:fertilization:plan:5d9d4b4e-14a2-4c5e-b038-f966ed892a32",
+                "@type": "TreatmentPlan",
+                "description": "The fertilisation type and dose derived after the soil analysis with id: 0123"
+            },
+            "hasApplicationMethod": "Dispration",
+            "operationType": "Dispration",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:fertilization:6b28bde8-a1d3-41ba-bdb2-7ae67916b3e8",
+            "@type": "FertilizationOperation",
+            "description": "\u03ac\u03bb\u03bb\u03b7 \u03bc\u03ad\u03b8\u03bf\u03b4\u03bf\u03c2",
+            "hasTimestamp": "2023-06-14",
+            "usesFertilizer": {
+                "@id": "urn:openagri:fertilization:product:3a6486bb-4510-46bd-92e1-882ac70024d4",
+                "@type": "Fertilizer",
+                "hasCommercialName": "AMINO 16"
+            },
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:fertilization:amount:68e1932c-2437-4493-aa34-aa564c65c1e2",
+                "@type": "QuantityValue",
+                "numericValue": "1.000",
+                "unit": null
+            },
+            "plan": {
+                "@id": "urn:openagri:fertilization:plan:adf31cc4-9edf-41a8-b425-de8135b9919d",
+                "@type": "TreatmentPlan",
+                "description": null
+            },
+            "hasApplicationMethod": "liquid foliar fertilizer",
+            "operationType": "liquid foliar fertilizer",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb"
+        },
+        {
+            "@id": "urn:openagri:fertilization:deb9365d-a373-4a34-911a-905b6f278768",
+            "@type": "FertilizationOperation",
+            "description": "Basal Fertlization",
+            "hasTimestamp": "2023-02-29",
+            "usesFertilizer": {
+                "@id": "urn:openagri:fertilization:product:67315eb3-94d2-4534-a080-13506431209e",
+                "@type": "Fertilizer",
+                "hasCommercialName": "ENTEC 20-8-10(+2Mgo+3S)"
+            },
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:fertilization:amount:55244a5f-a091-41a4-9877-1befb113c7c3",
+                "@type": "QuantityValue",
+                "numericValue": "5",
+                "unit": "https://w3id.org/ocsm/KiloGM-PER-PLANT"
+            },
+            "plan": {
+                "@id": "urn:openagri:fertilization:plan:02652b00-3598-49d0-92e4-e1aab37a9ff0",
+                "@type": "TreatmentPlan",
+                "description": "The fertilisation type and dose derived after the soil analysis with id: 0123"
+            },
+            "hasApplicationMethod": "Dispration",
+            "operationType": "Dispration",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4"
+        },
+        {
+            "@id": "urn:openagri:fertilization:8de97069-e236-46b4-9c57-6c116970ba84",
+            "@type": "FertilizationOperation",
+            "description": "\u03ac\u03bb\u03bb\u03b7 \u03bc\u03ad\u03b8\u03bf\u03b4\u03bf\u03c2",
+            "hasTimestamp": "2023-06-24",
+            "usesFertilizer": {
+                "@id": "urn:openagri:fertilization:product:64ca3d37-171b-491d-b90c-e6065dc2aa22",
+                "@type": "Fertilizer",
+                "hasCommercialName": "AMINO 16"
+            },
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:fertilization:amount:402d97d9-3d8d-45fa-ba0b-3ec964d63975",
+                "@type": "QuantityValue",
+                "numericValue": "1.5",
+                "unit": null
+            },
+            "plan": {
+                "@id": "urn:openagri:fertilization:plan:afff3504-22d5-4499-b4f8-e35abf5587ad",
+                "@type": "TreatmentPlan",
+                "description": null
+            },
+            "hasApplicationMethod": "liquid foliar fertilizer",
+            "operationType": "liquid foliar fertilizer",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4"
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:f0e06d1e-37c8-4248-ade6-bc3608f07052",
+            "@type": "ChemicalControlOperation",
+            "description": "This was a preventive application. No prior symptoms detected.",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:87ea0074-16bc-42e9-9799-5974e4a7a2c5",
+                "@type": "QuantityValue",
+                "numericValue": 1176.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-02-07",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:7baf576b-c916-49c1-bb31-4a6458730de2",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Bordeaux mixture",
+                "hasCommercialName": "BORDELESA 20 WP"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:f0850ab5-cf60-46b9-92ce-fa50907d7942",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:1aeef8e7-03c9-4119-9ade-a7c2e1802cdb",
+                "@type": "QuantityValue",
+                "numericValue": 588.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-03-16",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:3a46a8aa-9b13-4bce-bdb0-6aca4d841ced",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Copper hydroxide",
+                "hasCommercialName": "KOCIDE 2000 35 WG"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:9ea348e2-7b8f-413b-96a6-7bb389c1181b",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:1edce227-f986-4b48-8f05-179897116e17",
+                "@type": "QuantityValue",
+                "numericValue": 470.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-04-08",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:c0d336ce-d260-412e-a493-24e8bb1b8031",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Pyraclostrobin",
+                "hasCommercialName": "COMET 20 EC"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:80449ee1-19ab-41e5-984a-4f6149318c1b",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:7e2b2f50-df29-45eb-adb3-b18cd4bf01df",
+                "@type": "QuantityValue",
+                "numericValue": 200.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-04-08",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:299bbe0f-8161-47c1-ab95-dea96682d0f8",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Mancozeb",
+                "hasCommercialName": "TRIMANOC 75 WG"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:3b3be4b0-aebd-4c13-8078-ec5f6ae9cdd8",
+            "@type": "ChemicalControlOperation",
+            "description": "\u03ba\u03b1\u03b9 KSAR",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:040f03fe-4912-4808-be8d-0394670c0d1f",
+                "@type": "QuantityValue",
+                "numericValue": 150.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-04-28",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:93a25cd9-5ac0-4293-b072-60287ce6f26e",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Dodine",
+                "hasCommercialName": "SYLLIT 544 SC"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:e8d1a7a7-f808-4a16-be5b-702ca2be661c",
+            "@type": "ChemicalControlOperation",
+            "description": "ACTELIC \u039a\u0391\u0399 \u0394\u0399\u0391\u03a6\u03a5\u039b\u039b\u0399\u039a\u0391",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:79d60a3d-eb8f-4818-a28a-a6111f604503",
+                "@type": "QuantityValue",
+                "numericValue": 100.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-05-11",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:ed817537-96d8-4724-9b2a-d0807e96b55c",
+                "@type": "Pesticide",
+                "hasActiveSubstance": null,
+                "hasCommercialName": "LAINCOIL"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:1c97b21c-4ed6-44bf-a879-550ead35cf21",
+            "@type": "ChemicalControlOperation",
+            "description": "\u03ba\u03b1\u03b9 \u0394\u0399\u0391\u03a6\u03a5\u039b\u039b\u0399\u039a\u0391.",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:e94aea0e-c627-4d8b-8bc0-89e4c530bff9",
+                "@type": "QuantityValue",
+                "numericValue": 30.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-05-19",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Basin or black olive scab",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:f76d59c4-7c5e-4ebf-bc4f-f5c9bf2dc56f",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Pyriproxyfen",
+                "hasCommercialName": "ADMIRAL 10 EC"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:d4f54be9-882b-4ca6-ad2c-43fe59a18984",
+            "@type": "ChemicalControlOperation",
+            "description": "\u03ba\u03b1\u03b9 \u0394\u0399\u0391\u03a6\u03a5\u039b\u039b\u0399\u039a\u0391.",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:794a59a3-537a-4c45-a5a5-78f8529bdcb3",
+                "@type": "QuantityValue",
+                "numericValue": 100.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-05-19",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Prays Oleae",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:de3393b7-2563-4913-8c6a-0d6591ae76a3",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Deltamethrin",
+                "hasCommercialName": "DECIS 2,5 EC"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:bd69747c-96c5-48de-b42e-865a85c0dc59",
+            "@type": "ChemicalControlOperation",
+            "description": "\u039f \u03c0\u03b1\u03c1\u03b1\u03b3\u03c9\u03b3\u03cc\u03c2 \u03c8\u03ad\u03ba\u03b1\u03c3\u03b5 \u03bc\u03b5 \u03c4\u03bf \u03c3\u03ba\u03b5\u03cd\u03b1\u03c3\u03bc\u03b1 Actellic 50 EC (\u03b4\u03c1\u03b1\u03c3\u03c4\u03b9\u03ba\u03ae \u03bf\u03c5\u03c3\u03af\u03b1 50% pirimiphos-methyl)",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:4dfcdc0a-0eaf-4d04-a6c5-f7786e60ac40",
+                "@type": "QuantityValue",
+                "numericValue": 100.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-06-01",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:edc5fcb6-40e4-4711-bd02-63173ee2a70b",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Pirimiphos-methyl",
+                "hasCommercialName": null
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:416d5be3-54bd-4881-8fb9-9a4c9bbffc09",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:6fda8201-113e-4f3b-8f95-df30eb355097",
+                "@type": "QuantityValue",
+                "numericValue": 20.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-06-14",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Prays Oleae",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:3646d60a-6d77-4c8f-8d6e-76028d20041b",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "lambda-cyhalothrin",
+                "hasCommercialName": "KARATE with Zeon technology 10 CS"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:4e477e52-2b05-4d52-9e1b-f90bc27cf08c",
+            "@type": "ChemicalControlOperation",
+            "description": "Intervention by advice. It also acts against gliosporium",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:bab295ef-e583-47f3-992f-44c639551bf8",
+                "@type": "QuantityValue",
+                "numericValue": 320.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-08-29",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:5c930c32-ac93-4a66-922a-1c8ce1b1ef71",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Copper hydroxide",
+                "hasCommercialName": "JADE 40 WG"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:1de1f203-f347-455f-a40f-4650e5c60dfe",
+            "@type": "ChemicalControlOperation",
+            "description": "Intervention by advice. It also acts against gliosporium",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:eb4b4a56-4af4-4d92-ba15-14a77f6fdab2",
+                "@type": "QuantityValue",
+                "numericValue": 250.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-11-18",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:0ac852e3-6614-4074-a318-c9266ab5b35e",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Copper hydroxide",
+                "hasCommercialName": "CUPROS 50 WP"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:5cae9bd3-bda5-4cfc-9881-0cd6bcb88467",
+            "@type": "ChemicalControlOperation",
+            "description": "Intervention by advice. It also acts against gliosporium",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:a1dcb82f-e1dd-4fd3-bdec-7179185dd39d",
+                "@type": "QuantityValue",
+                "numericValue": 500.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-12-13",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:da4cf1f8-a829-4559-8728-668110dd62fb",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:0483e358-3972-4ad5-aa02-2bbdc872698d",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Bordeaux mixture",
+                "hasCommercialName": "AQQUOS 20 WP"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:a285bae9-d35b-48ca-97d5-355551182c57",
+            "@type": "ChemicalControlOperation",
+            "description": "This was a preventive application. No prior symptoms detected.",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:d8e67df6-5569-431f-b36f-3b49a7450ca2",
+                "@type": "QuantityValue",
+                "numericValue": 1100.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-02-08",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:6df37146-755f-44e0-84a5-58e99fe773ef",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Bordeaux mixture",
+                "hasCommercialName": "BORDELESA 20 WP"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:9ff7470f-7bb9-4113-8114-86c1655dd919",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:639d985c-c283-4c31-8811-23b8d8ec5272",
+                "@type": "QuantityValue",
+                "numericValue": 550.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-03-26",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:180fa12e-789e-4b18-8ed7-f1b44f891792",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Copper hydroxide",
+                "hasCommercialName": "KOCIDE 2000 35 WG"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:50728c94-18cd-40a9-ab4a-15b6fb1dd513",
+            "@type": "ChemicalControlOperation",
+            "description": null,
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:6142941b-6bca-463c-8a8d-4e7396e1223f",
+                "@type": "QuantityValue",
+                "numericValue": 490.0,
+                "unit": "http://qudt.org/vocab/unit/ML"
+            },
+            "hasTimestamp": "2023-04-12",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:b51739cd-d751-4dff-8468-6fd5cd46bb3f",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Pyraclostrobin",
+                "hasCommercialName": "COMET 20 EC"
+            }
+        },
+        {
+            "@id": "urn:openagri:pestMgmt:43aa2227-83f0-4c00-9e4c-e358d0fa7693",
+            "@type": "ChemicalControlOperation",
+            "description": "Intervention by advice. It also acts against gliosporium",
+            "hasAppliedAmount": {
+                "@id": "urn:openagri:pestMgmt:amount:6fd2766d-2a23-4b51-b801-5d6d6871935f",
+                "@type": "QuantityValue",
+                "numericValue": 510.0,
+                "unit": "http://qudt.org/vocab/unit/GM"
+            },
+            "hasTimestamp": "2023-12-15",
+            "hasTreatedArea": "null",
+            "isOperatedOn": "urn:openagri:parcel:e2f71ec4-202d-48ef-a778-e7cafae776d4",
+            "isTargetedTowards": "Powdery mildew",
+            "usesPesticide": {
+                "@id": "urn:openagri:pestMgmt:system:e7c8a05a-15b9-44a0-a5b4-f2e07b9167f3",
+                "@type": "Pesticide",
+                "hasActiveSubstance": "Bordeaux mixture",
+                "hasCommercialName": "AQQUOS 20 WP"
+            }
+        }
+    ]
+}

--- a/tests/farm_calendar_to_jsonld.py
+++ b/tests/farm_calendar_to_jsonld.py
@@ -1,0 +1,364 @@
+import json
+from pathlib import Path
+import uuid
+import sys
+
+import report_service_utils as report_srv
+
+
+# Function to generate a UUID with a specific prefix
+def generate_uuid(prefix):
+    return f"urn:openagri:{prefix}:{uuid.uuid4()}"
+
+
+# Function to create the filename for the extracted AIM model in JSON-LD
+def generate_aim_filename(generic_filename: str) -> str:
+    return f'{Path("example", "datasets", generic_filename).stem}_AIM.jsonld'
+
+
+# Function to map unit to vocabulary term
+def get_unit_uri(unit):
+        unit_mapping = {
+            "gr/ha": "http://qudt.org/vocab/unit/GM",
+            "ml/ha": "http://qudt.org/vocab/unit/ML"
+        }
+        return unit_mapping.get(unit, "")
+
+# Function to convert parcel data to JSON-LD format and create a mapping from parcelUniqueIdentifier to parcelId
+def convert_parcel_data(parcel_data_list):
+    parcel_mapping = {}
+    json_ld_parcels = []
+
+    for parcel in parcel_data_list:
+        parcel_id = generate_uuid("parcel")
+        parcel_mapping[parcel.get('parcelUniqueIdentifier')] = parcel_id
+
+        gis_data = parcel.get('gis', [{}])[0]
+
+        parcel_entry = {
+            "@id": parcel_id,
+            "@type": "Vineyard",
+            "identifier": parcel.get('parcelUniqueIdentifier', None),
+            "description": parcel.get('description', None),
+            "category": parcel.get('category', None),
+            "validFrom": parcel.get('validFrom', None),
+            "validTo": parcel.get('validTo', None),
+            "inRegion": parcel.get('inRegion', None),
+            "hasToponym": parcel.get('hasToponym', None),
+            "area": parcel.get('parcel_area') * 10000 if parcel.get('parcel_area') else None,  # Convert Ha to m²
+            "isNitroAarea": parcel.get('isNitroAarea', None),
+            "isNatura2000Area": parcel.get('isNatura2000Area', None),
+            "isPDOPGIArea": parcel.get('isPDOPGIArea', None),
+            "isIrrigated": parcel.get('isIrrigated', None),
+            "isCultivatedInLevels": parcel.get('isCultivatedInLevels', None),
+            "isGroundSlope": parcel.get('isGroundSlope', None),
+            "depiction": parcel.get('depiction', None),
+            "hasGeometry": {
+                "@id": generate_uuid("parcel:geo"),
+                "@type": "Polygon",
+                "asWKT": gis_data.get('wkt', None)
+            },
+            "location": {
+                "@id": generate_uuid("parcel:point"),
+                "@type": "Point",
+                "lat": gis_data.get('latitude', None),
+                "long": gis_data.get('longitude', None)
+            },
+            "usesIrrigationSystem": {
+                "@id": generate_uuid("parcel:irrigation"),
+                "@type": "IrrigationSystem",
+                "name": parcel.get('irrigation_system', None)
+            },
+            "hasIrrigationFlow": parcel.get('irrigation_supply_rate', None)
+        }
+
+        json_ld_parcels.append(parcel_entry)
+
+    return json_ld_parcels, parcel_mapping
+
+
+# Function to convert farm data to JSON-LD format
+def convert_farm_data(farm_data_list, json_ld_parcels):
+    json_ld_farms = []
+
+    for farm in farm_data_list:
+        farm_id = generate_uuid("farm")
+        
+        # Link parcels associated with the farm
+        farm_parcel_ids = farm.get('farm_parcel_ids', [])
+        linked_parcels = [
+            parcel for parcel in json_ld_parcels 
+            if parcel.get('identifier') in farm_parcel_ids
+        ]
+        
+        farm_entry = {
+            "@id": farm_id,
+            "@type": "Farm",
+            "name": farm.get('farmName', None),
+            "description": farm.get('description', None),
+            "hasAdministrator": farm.get('farmAdministratorName', None),
+            "contactPerson": {
+                "@id": generate_uuid("contact"),
+                "@type": "Person",
+                "firstname": farm.get('farmContactPerson', None),
+                "lastname": farm.get('farmContactPerson', None)
+            },
+            "telephone": farm.get('telephone', None),
+            "vatID": farm.get('vatID', None),
+            "address": {
+                "@id": generate_uuid("address"),
+                "@type": "Address",
+                "adminUnitL1": farm.get('adminUnitL1', None),
+                "adminUnitL2": farm.get('adminUnitL2', None),
+                "addressArea": farm.get('addressArea', None),
+                "municipality": farm.get('municipality', None),
+                "community": farm.get('community', None),
+                "locatorName": farm.get('locatorName', None)
+            },
+            "area": farm.get('totalFarmArea') * 10000 if farm.get('totalFarmArea') else None,  # Convert Ha to m²
+            "hasAgriParcel": linked_parcels  # Link the parcels related to this farm
+        }
+
+        json_ld_farms.append(farm_entry)
+
+    return json_ld_farms
+
+# Function to convert pesticides data to JSON-LD format and associate it with the corresponding parcelId
+def convert_pesticides_to_jsonld(pesticides_data, parcel_mapping):
+    json_ld_pesticides = []
+
+    for entry in pesticides_data:
+        base_id = generate_uuid("pestMgmt")
+        amount_id = generate_uuid("pestMgmt:amount")
+        system_id = generate_uuid("pestMgmt:system")
+
+        parcel_unique_identifier = entry.get('parcelUniqueIdentifier')
+        parcel_id = parcel_mapping.get(parcel_unique_identifier)
+
+        pesticides_entry = {
+            "@id": base_id,
+            "@type": "ChemicalControlOperation",
+            "description": entry.get("remarks", "treatment description"),
+            "hasAppliedAmount": {
+                "@id": amount_id,
+                "@type": "QuantityValue",
+                "numericValue": entry.get("dose"),
+                "unit": get_unit_uri(entry.get("unit"))
+            },
+            "hasTimestamp": entry.get("date"),
+            "hasTreatedArea": "null",  # Assuming no treated area info provided
+            "isOperatedOn": parcel_id,
+            "isTargetedTowards": entry.get("target"),
+            "usesPesticide": {
+                "@id": system_id,
+                "@type": "Pesticide",
+                "hasActiveSubstance": entry.get("activeSubstance"),
+                "hasCommercialName": entry.get("comercialDrugName")
+            }
+        }
+
+        json_ld_pesticides.append(pesticides_entry)
+
+    return json_ld_pesticides
+
+
+# Function to convert irrigation data to JSON-LD format and associate it with the corresponding parcelId
+def convert_irrigation_to_jsonld(irrigation_data, parcel_mapping):
+    json_ld_irrigation = []
+
+    for entry in irrigation_data:
+        base_id = generate_uuid("irrigation")
+        amount_id = generate_uuid("irrigation:amount")
+        system_id = generate_uuid("irrigation:system")
+
+        parcel_unique_identifier = entry.get('parcelUniqueIdentifier')
+        parcel_id = parcel_mapping.get(parcel_unique_identifier)
+
+        irrigation_entry = {
+            "@id": base_id,
+            "@type": "IrrigationOperation",
+            "description": "irrigation description",
+            "startedAt": entry.get("startDateTime", None),
+            "endedAt": entry.get("endDateTime", None),
+            "hasAppliedAmount": {
+                "@id": amount_id,
+                "@type": "QuantityValue",
+                "numericValue": entry.get("waterQuantity", None),
+                "unit": "http://qudt.org/vocab/unit/M3" if entry.get("unit") == "m3/Ha" else None
+            },
+            "usesIrrigationSystem": {
+                "@id": system_id,
+                "@type": "IrrigationSystem",
+                "name": entry.get("irrigationSystem", None),
+                "hasIrrigationType": entry.get("irrigationSystem", None)
+            },
+            "isOperatedOn": parcel_id
+        }
+
+        json_ld_irrigation.append(irrigation_entry)
+
+    return json_ld_irrigation
+
+# Function to convert fertilization data to JSON-LD format and associate it with the corresponding parcelId
+def convert_fertilization_to_jsonld(fertilizations_data, parcel_mapping):
+    json_ld_fertilization = []
+
+    for entry in fertilizations_data:
+        base_id = generate_uuid("fertilization")
+        product_id = generate_uuid("fertilization:product")
+        amount_id = generate_uuid("fertilization:amount")
+        plan_id = generate_uuid("fertilization:plan")
+
+        # Determine the correct unit vocabulary term
+        if entry.get("unit") == "kg" and entry.get("referenceDose") == "per plant":
+            unit_vocab = "https://w3id.org/ocsm/KiloGM-PER-PLANT"
+        elif entry.get("unit") == "liters" and entry.get("referenceDose") == "per hectare":
+            unit_vocab = "https://w3id.org/ocsm/Litres-PER-Hectar"
+        else:
+            unit_vocab = None
+
+        parcel_unique_identifier = entry.get('parcelUniqueIdentifier')
+        parcel_id = parcel_mapping.get(parcel_unique_identifier)
+
+        fertilization_entry = {
+            "@id": base_id,
+            "@type": "FertilizationOperation",
+            "description": entry.get("fertilization_description", "No description provided"),
+            "hasTimestamp": entry.get("date", None),
+            "usesFertilizer": {
+                "@id": product_id,
+                "@type": "Fertilizer",
+                "hasCommercialName": entry.get("product_name", None)
+            },
+            "hasAppliedAmount": {
+                "@id": amount_id,
+                "@type": "QuantityValue",
+                "numericValue": entry.get("dose", None),
+                "unit": unit_vocab
+            },
+            "plan": {
+                "@id": plan_id,
+                "@type": "TreatmentPlan",
+                "description": entry.get("remarks", "No plan description provided")
+            },
+            "hasApplicationMethod": entry.get("fertilization_application_method", None),
+            "operationType": entry.get("fertilization_application_method", None),
+            "isOperatedOn": parcel_id
+        }
+
+        json_ld_fertilization.append(fertilization_entry)
+
+    return json_ld_fertilization
+
+# Function to create a single combined JSON-LD file with all data under one "@graph" array
+def create_combined_jsonld(irrigation_data, fertilizations_data, pesticides_data, parcel_data):
+    combined_json_ld = {
+        "@context": ["https://w3id.org/ocsm/main-context.jsonld"],
+        "@graph": []
+    }
+
+    combined_json_ld["@graph"].extend(parcel_data)
+    combined_json_ld["@graph"].extend(irrigation_data)
+    combined_json_ld["@graph"].extend(fertilizations_data)
+    combined_json_ld["@graph"].extend(pesticides_data)
+
+    return combined_json_ld
+
+def main():
+    # Read the input JSON file from argv[1]
+    input_file = sys.argv[1]
+
+    with open(input_file, 'r', encoding="utf-8") as file:
+        input_data = json.load(file)
+    
+    irrigation_data = input_data.get("irrigation_data", [])
+    fertilizations_data = input_data.get("fertilizations_data", [])
+    pesticides_data = input_data.get("pesticides_data", [])
+    farm_data_list = input_data.get('farm_related_data', [])
+    parcel_data_list = input_data.get('parcel_related_data', [])
+    
+    # Convert parcel data and create a parcel mapping
+    json_ld_parcels, parcel_mapping = convert_parcel_data(parcel_data_list)
+    
+    if irrigation_data or fertilizations_data or farm_data_list:
+        choice = input("Data found. Choose output option:\n"
+                       "1. Dump irrigation data to console\n"
+                       "2. Dump fertilization data to console\n"
+                       "3. Dump pesticides data to console\n"
+                       "4. Dump farm and parcel data to console\n"
+                       "5. Write all data to separate files\n"
+                       "6. Write all data to one combined JSON-LD file\n"
+                       "Enter choice (1/2/3/4/5/6): ")
+
+        if choice == '1' and irrigation_data:
+            converted_data = convert_irrigation_to_jsonld(irrigation_data, parcel_mapping)
+            print(json.dumps(converted_data, indent=4))
+        elif choice == '2' and fertilizations_data:
+            converted_data = convert_fertilization_to_jsonld(fertilizations_data, parcel_mapping)
+            print(json.dumps(converted_data, indent=4))
+        elif choice == '3' and pesticides_data:
+            converted_data = convert_pesticides_to_jsonld(pesticides_data, parcel_mapping)
+            print(json.dumps(converted_data, indent=4))
+        elif choice == '4' and farm_data_list:
+            converted_farm_data = convert_farm_data(farm_data_list, json_ld_parcels)
+            print(json.dumps(converted_farm_data, indent=4))
+        elif choice == '5':
+            dir_path = Path("example", "datasets")
+
+            if irrigation_data:
+                irrigation_output = convert_irrigation_to_jsonld(irrigation_data, parcel_mapping)
+                with open(dir_path.joinpath('irrigation_output.jsonld'), 'w') as irrig_file:
+                    json.dump(irrigation_output, irrig_file, indent=4)
+                print("Irrigation data written to irrigation_output.jsonld")
+
+            if fertilizations_data:
+                fertilization_output = convert_fertilization_to_jsonld(fertilizations_data, parcel_mapping)
+                with open(dir_path.joinpath('fertilization_output.jsonld'), 'w') as fert_file:
+                    json.dump(fertilization_output, fert_file, indent=4)
+                print("Fertilization data written to fertilization_output.jsonld")
+
+            if pesticides_data:
+                pesticides_output = convert_fertilization_to_jsonld(pesticides_data, parcel_mapping)
+                with open(dir_path.joinpath('pesticides_output.jsonld'), 'w') as pest_file:
+                    json.dump(pesticides_output, pest_file, indent=4)
+                print("Pesticides data written to fertilization_output.jsonld")
+
+            if farm_data_list:
+                farm_output = convert_farm_data(farm_data_list, json_ld_parcels)
+                with open(dir_path.joinpath('farm_output.jsonld'), 'w') as farm_file:
+                    json.dump(farm_output, farm_file, indent=4)
+                print("Farm data written to farm_output.jsonld")
+
+        elif choice == '6':  # Combined JSON-LD file option
+            irrigation_output = convert_irrigation_to_jsonld(irrigation_data, parcel_mapping)
+            fertilization_output = convert_fertilization_to_jsonld(fertilizations_data, parcel_mapping)
+            pesticides_output = convert_pesticides_to_jsonld(pesticides_data, parcel_mapping)
+            farm_output = convert_farm_data(farm_data_list, json_ld_parcels)
+            combined_output = create_combined_jsonld(irrigation_output, fertilization_output, pesticides_output, farm_output)
+
+            aim_farm_calendar_filename = Path("example", "datasets", generate_aim_filename(input_file))
+
+            with open(aim_farm_calendar_filename, 'w') as combined_file:
+                json.dump(combined_output, combined_file, indent=4)
+            print("All data written to combined_output.jsonld")
+
+            hasReport = input("Do you want to create a PDF report? (Y/N)")
+            if hasReport == "Y":
+
+                report_types = ['work-book', 'plant-protection', 'irrigations', 'fertilisations', 'harvests', 'GlobalGAP']
+                report_srv.register()
+                token = report_srv.authenticate()
+                dataset_id = report_srv.upload_dataset(aim_farm_calendar_filename, token)
+                report_srv.generate_reports_for_dataset(dataset_id, report_types, token, isDownload=True)
+
+
+
+
+        else:
+            print("Invalid choice or no data for the selected option.")
+    else:
+        print("No recognizable data type found in the input file.")
+
+if __name__ == "__main__":
+
+    main()

--- a/tests/report_service_utils.py
+++ b/tests/report_service_utils.py
@@ -1,0 +1,112 @@
+import requests
+
+
+REPORTING_SERVICE_URL = "http://localhost:80"
+
+def register():
+    r = requests.post(
+        url=REPORTING_SERVICE_URL + "/api/v1/user/register/",
+        json={"email": "test.test@example.com", "password": "Test123321"}
+    )
+
+    return None
+
+# This function is used to authenticate to the reporting service by making a POST request
+# to the "/api/v1/login/access-token/" endpoint using a predefined username and password.
+# It retrieves the access token from the response and returns it.
+# If the authentication request fails (non-200 status code), the function returns nothing.
+def authenticate() -> str:
+    r = requests.post(
+    REPORTING_SERVICE_URL + "/api/v1/login/access-token/",
+        data={'username': 'test.test@example.com', 'password': 'Test123321'},
+        timeout=10
+    )
+    token = r.json()['access_token']
+
+    if r.status_code != 200:
+        return
+
+    return token
+
+
+# Makes a POST request to upload the dataset to the reporting service.
+# The Authorization header is set using the provided token.
+# The file at the specified file path is included in the request as the 'data' payload.
+# If the request is successful, extracts the dataset ID from the response.
+def upload_dataset(farm_calendar_aim_filepath: str, token: str) -> int:
+    r = requests.post(
+        REPORTING_SERVICE_URL + "/api/v1/openagri-dataset/",
+        headers={'Authorization': f'Bearer {token}'},
+        # Define the file to upload
+        files = {
+            # 'data': json.dumps(combined_output)
+            'data': open(farm_calendar_aim_filepath, 'rb')
+            },
+        timeout=5
+        )
+
+    if r.status_code != 200:
+        return
+
+    dataset_id = r.json()['id']
+    print(f'Dataset uploaded with id: {dataset_id}')
+    return dataset_id
+
+# Makes a POST request to generate a report based on a dataset ID and report type.
+# The Authorization header is set using the provided token.
+# If the request is successful, extracts the report ID from the response.
+# If the request fails (status_code != 200), it returns None.
+def generate_report(dataset_id: int, report_type: str, token: str) -> int:
+    r = requests.post(
+        REPORTING_SERVICE_URL + f"/api/v1/openagri-report/{report_type}/dataset/{dataset_id}",
+        headers={'Authorization': f'Bearer {token}'},
+        timeout=5
+    )
+
+    if r.status_code != 200:
+        return
+
+    report_id = r.json()['id']
+    print(f'{report_type} report created with id: {report_id}')
+    return report_id
+
+
+# Makes a GET request to download a report using the provided report ID.
+# The Authorization header is set using the provided token.
+# If the request is successful, writes the report content to a PDF file named 'report_<report_id>.pdf'.
+# If the request fails (status_code != 200), it returns None.
+def download_report(report_id: int, token: str, report_type=None):
+    r = requests.get(
+        REPORTING_SERVICE_URL + f"/api/v1/openagri-report/{report_id}",
+        headers={'Authorization': f'Bearer {token}'},
+        timeout=5
+    )
+
+    if r.status_code != 200:
+        return
+
+    from pathlib import Path
+
+    pdf_report = r.content
+    report_name = f'report_{report_id}_{report_type}.pdf' if report_type else f'report_{report_id}'
+    with open(Path("example", "reports", report_name), 'wb') as pdf:
+        pdf.write(pdf_report)
+    print(f'Downloaded report: {report_name} for report with id: {report_id}')
+    return report_name
+
+
+def generate_reports_for_dataset(dataset_id: str, types: list, token: str, isDownload: bool=True):
+
+    report_ids = []
+    for t in types:
+        report_ids.append((generate_report(dataset_id, t, token), t))
+
+    if not isDownload:
+        return
+
+    report_names = []
+    for id, report_type in report_ids:
+        report_names.append(download_report(id, token, report_type))
+
+    print("All reports downloaded!\n"
+          f"{report_names}\n")

--- a/tests/tests_.py
+++ b/tests/tests_.py
@@ -1,9 +1,5 @@
 import pytest
-
-from app.main import app
-from fastapi.testclient import TestClient
-
-client = TestClient(app)
+import requests
 
 
 @pytest.fixture()
@@ -24,8 +20,8 @@ def user_login():
 
 @pytest.mark.order(1)
 def test_access_token():
-    response = client.post(
-        url="api/v1/login/access-token/",
+    response = requests.post(
+        url="http://localhost/api/v1/login/access-token/",
         data={"username": "stefan.drobic@vizlore.com", "password": "Windows8"},
     )
 
@@ -34,8 +30,8 @@ def test_access_token():
 
 @pytest.mark.order(2)
 def test_delete_user_not_logged():
-    response = client.delete(
-        url="api/v1/user/"
+    response = requests.delete(
+        url="http://localhost/api/v1/user/"
     )
 
     assert response.status_code == 401
@@ -44,8 +40,8 @@ def test_delete_user_not_logged():
 @pytest.mark.order(3)
 def test_user_flow(user_payload, user_login):
     # Register
-    response = client.post(
-        url="api/v1/user/register/",
+    response = requests.post(
+        url="http://localhost/api/v1/user/register/",
         json=user_payload,
     )
 
@@ -53,8 +49,8 @@ def test_user_flow(user_payload, user_login):
     assert response.json()["message"] == "You have successfully registered!"
 
     # Login
-    response = client.post(
-        url="api/v1/login/access-token/",
+    response = requests.post(
+        url="http://localhost/api/v1/login/access-token/",
         data=user_login
     )
 
@@ -65,8 +61,8 @@ def test_user_flow(user_payload, user_login):
     access_token = response.json()["access_token"]
 
     # Remove
-    response = client.delete(
-        url="api/v1/user/",
+    response = requests.delete(
+        url="http://localhost/api/v1/user/",
         headers={
             "authorization": "bearer {}".format(access_token)
         }
@@ -79,8 +75,8 @@ def test_user_flow(user_payload, user_login):
 @pytest.mark.order(4)
 def test_data_flow(user_payload, user_login):
     # Register
-    response = client.post(
-        url="api/v1/user/register/",
+    response = requests.post(
+        url="http://localhost/api/v1/user/register/",
         json=user_payload,
     )
 
@@ -88,8 +84,8 @@ def test_data_flow(user_payload, user_login):
     assert response.json()["message"] == "You have successfully registered!"
 
     # Login
-    response = client.post(
-        url="api/v1/login/access-token/",
+    response = requests.post(
+        url="http://localhost/api/v1/login/access-token/",
         data=user_login
     )
 
@@ -102,8 +98,8 @@ def test_data_flow(user_payload, user_login):
     # Upload Data
     file = open("test.json", "rb")
 
-    response = client.post(
-        url="api/v1/openagri-dataset/",
+    response = requests.post(
+        url="http://localhost/api/v1/openagri-dataset/",
         headers={
             "authorization": "bearer {}".format(access_token)
         },
@@ -119,8 +115,8 @@ def test_data_flow(user_payload, user_login):
     data_id = response.json()["id"]
 
     # Get Data
-    response = client.get(
-        url="api/v1/openagri-dataset/{}".format(data_id),
+    response = requests.get(
+        url="http://localhost/api/v1/openagri-dataset/{}".format(data_id),
         headers={
             "authorization": "bearer {}".format(access_token)
         }
@@ -129,8 +125,8 @@ def test_data_flow(user_payload, user_login):
     assert response.status_code == 200
 
     # Remove Data
-    response = client.delete(
-        url="api/v1/openagri-dataset/{}".format(data_id),
+    response = requests.delete(
+        url="http://localhost/api/v1/openagri-dataset/{}".format(data_id),
         headers={
             "authorization": "bearer {}".format(access_token)
         }
@@ -141,8 +137,8 @@ def test_data_flow(user_payload, user_login):
     assert response.json()["message"] == "Successfully removed dataset with ID:{}.".format(data_id)
 
     # Delete User
-    response = client.delete(
-        url="api/v1/user/",
+    response = requests.delete(
+        url="http://localhost/api/v1/user/",
         headers={
             "authorization": "bearer {}".format(access_token)
         }
@@ -155,8 +151,8 @@ def test_data_flow(user_payload, user_login):
 @pytest.mark.order(5)
 def test_report_flow(user_payload, user_login):
     # Register
-    response = client.post(
-        url="api/v1/user/register/",
+    response = requests.post(
+        url="http://localhost/api/v1/user/register/",
         json=user_payload,
     )
 
@@ -164,8 +160,8 @@ def test_report_flow(user_payload, user_login):
     assert response.json()["message"] == "You have successfully registered!"
 
     # Login
-    response = client.post(
-        url="api/v1/login/access-token/",
+    response = requests.post(
+        url="http://localhost/api/v1/login/access-token/",
         data=user_login
     )
 
@@ -178,8 +174,8 @@ def test_report_flow(user_payload, user_login):
     # Upload Data
     file = open("test.json", "rb")
 
-    response = client.post(
-        url="api/v1/openagri-dataset/",
+    response = requests.post(
+        url="http://localhost/api/v1/openagri-dataset/",
         headers={
             "authorization": "bearer {}".format(access_token)
         },
@@ -198,8 +194,8 @@ def test_report_flow(user_payload, user_login):
     report_types = ["work-book", "plant-protection", "irrigations", "fertilisations", "harvests", "GlobalGAP"]
     report_ids = []
     for rt in report_types:
-        response = client.post(
-            url="api/v1/openagri-report/{report_type}/dataset/{dataset_id}".format(report_type=rt, dataset_id=data_id),
+        response = requests.post(
+            url="http://localhost/api/v1/openagri-report/{report_type}/dataset/{dataset_id}".format(report_type=rt, dataset_id=data_id),
             headers={
                 "authorization": "bearer {}".format(access_token)
             }
@@ -212,8 +208,8 @@ def test_report_flow(user_payload, user_login):
 
     # Get Report
     for ri in report_ids:
-        response = client.get(
-            url="api/v1/openagri-report/{}".format(ri),
+        response = requests.get(
+            url="http://localhost/api/v1/openagri-report/{}".format(ri),
             headers={
                 "authorization": "bearer {}".format(access_token)
             }
@@ -225,8 +221,8 @@ def test_report_flow(user_payload, user_login):
 
     # Delete Report
     for ri in report_ids:
-        response = client.delete(
-            url="api/v1/openagri-report/{}".format(ri),
+        response = requests.delete(
+            url="http://localhost/api/v1/openagri-report/{}".format(ri),
             headers={
                 "authorization": "bearer {}".format(access_token)
             }
@@ -237,8 +233,8 @@ def test_report_flow(user_payload, user_login):
         assert response.json()["message"] == "Successfully deleted report with ID:{}.".format(ri)
 
     # Remove Data
-    response = client.delete(
-        url="api/v1/openagri-dataset/{}".format(data_id),
+    response = requests.delete(
+        url="http://localhost/api/v1/openagri-dataset/{}".format(data_id),
         headers={
             "authorization": "bearer {}".format(access_token)
         }
@@ -249,8 +245,8 @@ def test_report_flow(user_payload, user_login):
     assert response.json()["message"] == "Successfully removed dataset with ID:{}.".format(data_id)
 
     # Delete User
-    response = client.delete(
-        url="api/v1/user/",
+    response = requests.delete(
+        url="http://localhost/api/v1/user/",
         headers={
             "authorization": "bearer {}".format(access_token)
         }

--- a/tests/tests_.py
+++ b/tests/tests_.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 import requests
 
@@ -5,83 +6,25 @@ import requests
 @pytest.fixture()
 def user_payload():
     return {
-        "email": "test@example.com",
-        "password": "TestPassword10"
+        "email": "test.test@example.com",
+        "password": "Test123321"
     }
 
 
 @pytest.fixture()
 def user_login():
     return {
-        "username": "test@example.com",
-        "password": "TestPassword10"
+        "username": "test.test@example.com",
+        "password": "Test123321"
     }
 
-
 @pytest.mark.order(1)
-def test_access_token():
-    response = requests.post(
-        url="http://localhost/api/v1/login/access-token/",
-        data={"username": "stefan.drobic@vizlore.com", "password": "Windows8"},
-    )
-
-    assert response.status_code == 200
-
-
-@pytest.mark.order(2)
-def test_delete_user_not_logged():
-    response = requests.delete(
-        url="http://localhost/api/v1/user/"
-    )
-
-    assert response.status_code == 401
-
-
-@pytest.mark.order(3)
-def test_user_flow(user_payload, user_login):
-    # Register
-    response = requests.post(
-        url="http://localhost/api/v1/user/register/",
-        json=user_payload,
-    )
-
-    assert response.status_code == 200
-    assert response.json()["message"] == "You have successfully registered!"
-
-    # Login
-    response = requests.post(
-        url="http://localhost/api/v1/login/access-token/",
-        data=user_login
-    )
-
-    assert response.status_code == 200
-    assert "access_token" in response.json()
-    assert "token_type" in response.json()
-
-    access_token = response.json()["access_token"]
-
-    # Remove
-    response = requests.delete(
-        url="http://localhost/api/v1/user/",
-        headers={
-            "authorization": "bearer {}".format(access_token)
-        }
-    )
-
-    assert response.status_code == 200
-    assert response.json()["message"] == "Successfully deleted user."
-
-
-@pytest.mark.order(4)
 def test_data_flow(user_payload, user_login):
     # Register
     response = requests.post(
         url="http://localhost/api/v1/user/register/",
         json=user_payload,
     )
-
-    assert response.status_code == 200
-    assert response.json()["message"] == "You have successfully registered!"
 
     # Login
     response = requests.post(
@@ -96,7 +39,7 @@ def test_data_flow(user_payload, user_login):
     access_token = response.json()["access_token"]
 
     # Upload Data
-    file = open("test.json", "rb")
+    file = open(Path("example", "datasets", "example_farm_calendar_AIM.jsonld"), "rb")
 
     response = requests.post(
         url="http://localhost/api/v1/openagri-dataset/",
@@ -148,16 +91,13 @@ def test_data_flow(user_payload, user_login):
     assert response.json()["message"] == "Successfully deleted user."
 
 
-@pytest.mark.order(5)
+@pytest.mark.order(2)
 def test_report_flow(user_payload, user_login):
     # Register
     response = requests.post(
         url="http://localhost/api/v1/user/register/",
         json=user_payload,
     )
-
-    assert response.status_code == 200
-    assert response.json()["message"] == "You have successfully registered!"
 
     # Login
     response = requests.post(
@@ -172,7 +112,7 @@ def test_report_flow(user_payload, user_login):
     access_token = response.json()["access_token"]
 
     # Upload Data
-    file = open("test.json", "rb")
+    file = open(Path("example", "datasets", "example_farm_calendar_AIM.jsonld"), "rb")
 
     response = requests.post(
         url="http://localhost/api/v1/openagri-dataset/",

--- a/tests/tests_.py
+++ b/tests/tests_.py
@@ -18,6 +18,7 @@ def user_login():
         "password": "Test123321"
     }
 
+
 @pytest.mark.order(1)
 def test_data_flow(user_payload, user_login):
     # Register


### PR DESCRIPTION
@fedjo @nikoskal This PR adds the converter scripts from [here](https://github.com/openagri-eu/OCSM/tree/main/converters) as a means of testing the service and generating reports for ease of use for the end user.
It also contains the necessary .json and .jsonld files, an empty dir that will contain any generated reports via the converter script, and updates to the README file with instructions on how to use the converter script, and descriptions on what it does and where it stores the reports.

The changes made to the converter scripts are mostly where it should store reports (in the /tests/example/reports/ dir) and the converted dataset (in the /tests/example/datesets/ dir), I've also included the translated AIM .jsonld as well, since the pytest tests use that one.