### PR TITLE
29 add background fastapi tasks for pdf generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 .alembic
 __pycache__
 .env
+app/user_reports

--- a/README.md
+++ b/README.md
@@ -51,8 +51,25 @@ docker compose up
 
 The application will be served on http://127.0.0.1:8009 (I.E. typing localhost/docs in your browser will load the swagger documentation)
 
-Full list of APIs available you can check [here](https://editor-next.swagger.io/?url=https://gist.githubusercontent.com/JoleVLF/20645c6e8e3545d02c7c4570271bdc49/raw/6efafb74bd2bc33e4221ee2a202d0c830b867c70/reporting)
+Full list of APIs available you can check [here](https://editor-next.swagger.io/?url=https://gist.githubusercontent.com/JoleVLF/b1bcdd77ac82aeb115a6c94fb3dadbdc/raw/4ce7fea5b022142002d0dfebcd2156a3e408fbe4/api.json)
 # Documentation
+<h3>GET</h3>
+
+```
+/api/v1/openagri-report/{report_id}/
+```
+
+## Path Params
+
+### report_id
+- **Type**: `uuid str`
+- **Description**: UUID of the generated PDF file..
+
+
+## Response
+
+Response is generated PDF file.
+
 <h3>POST</h3>
 
 ```
@@ -69,8 +86,7 @@ Full list of APIs available you can check [here](https://editor-next.swagger.io/
 
 ## Response
 
-Response is generated PDF file.
-
+Response is uuid of generated PDF file.
 
 <h3>POST</h3>
 
@@ -95,13 +111,13 @@ Response is generated PDF file.
 
 
 ## Response 
-Response is generated PDF file.
+Response is uuid of generated PDF file.
 
 <h3> Example usage </h3>
 
 Compost and Irrigation Report APIs can be used with and without Gatekeeper support.
 If Gatekeeper is used, data file param can be ignored.
-When service is run wihtout Gatekeeper data must be provided in .json file format.
+When service is run without Gatekeeper data must be provided in .json file format.
 
 
 ```shell
@@ -142,7 +158,7 @@ If a valid JSON file is uploaded, the API processes the data directly to generat
 
 ## Response
 
-Response is generated PDF file.
+Response is uuid of generated PDF file.
 
 <h2>Pytest</h2>
 Pytest can be run on the same machine the service has been deployed to by moving into the tests dir and running:

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -70,7 +70,9 @@ async def generate_irrigation_report(
         uuid_of_pdf = str(uuid.uuid4())
 
         background_tasks.add_task(
-            process_irrigation_data, json_data=farm_calendar_irrigation_response
+            process_irrigation_data,
+            json_data=farm_calendar_irrigation_response,
+            pdf_file_name=uuid_of_pdf,
         )
 
         return uuid_of_pdf
@@ -82,6 +84,7 @@ async def generate_irrigation_report(
             background_tasks.add_task(
                 process_irrigation_data,
                 json_data=json.load(data.file),
+                pdf_file_name=uuid_of_pdf,
             )
 
             return uuid_of_pdf
@@ -157,6 +160,7 @@ async def generate_generic_observation_report(
             activity_type_info=observation_type_name,
             observations=observations,
             farm_activities=farm_activities,
+            pdf_file_name=uuid_of_pdf,
         )
 
         return uuid_of_pdf
@@ -172,6 +176,7 @@ async def generate_generic_observation_report(
                 activity_type_info=observation_type_name,
                 observations=dt["observations"],
                 farm_activities=dt["farm_activities"],
+                pdf_file_name=uuid_of_pdf,
             )
 
             return uuid_of_pdf

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from json import JSONDecodeError
 from typing import Optional
@@ -42,7 +43,14 @@ def retrieve_generated_pdf(
         if settings.REPORTING_USING_GATEKEEPER
         else token.id
     )
+
     file_path = f"{settings.PDF_DIRECTORY}{user_id}/{report_id}.pdf"
+
+    if not os.path.exists(file_path):
+        raise HTTPException(
+            status_code=404,
+            detail=f"File with uuid {report_id} for logged user not found.",
+        )
 
     return FileResponse(
         path=file_path, media_type="application/pdf", filename=f"{report_id}"

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -21,23 +21,31 @@ from utils.animals_report import process_animal_data
 from utils.farm_calendar_report import process_farm_calendar_data
 from utils.irrigation_report import process_irrigation_data
 from utils.json_handler import make_get_request
+from fastapi.responses import FileResponse
 
 router = APIRouter()
 
 
-@router.get("{report_id}")
+@router.get("{report_id}", response_class=FileResponse)
 def retrieve_generated_pdf(
     report_id: str,
-    background_tasks: BackgroundTasks,
     token=Depends(deps.get_current_user),
 ):
-    pass
-
     """
 
     Retrieve generated PDF file
 
     """
+    user_id = (
+        decode_jwt_token(token)["user_id"]
+        if settings.REPORTING_USING_GATEKEEPER
+        else token.id
+    )
+    file_path = f"{settings.PDF_DIRECTORY}{user_id}/{report_id}.pdf"
+
+    return FileResponse(
+        path=file_path, media_type="application/pdf", filename=f"{report_id}"
+    )
 
 
 @router.post("/irrigation-report/")

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -16,6 +16,7 @@ from pydantic import UUID4
 
 from api import deps
 from core import settings
+from schemas import PDF
 from utils import decode_jwt_token
 from utils.animals_report import process_animal_data
 from utils.farm_calendar_report import process_farm_calendar_data
@@ -48,7 +49,7 @@ def retrieve_generated_pdf(
     )
 
 
-@router.post("/irrigation-report/")
+@router.post("/irrigation-report/", response_model=PDF)
 async def generate_irrigation_report(
     background_tasks: BackgroundTasks,
     token=Depends(deps.get_current_user),
@@ -58,13 +59,13 @@ async def generate_irrigation_report(
     Generates Irrigation Report PDF file
 
     """
-    uuid_of_pdf = str(uuid.uuid4())
+    uuid_v4 = str(uuid.uuid4())
     user_id = (
         decode_jwt_token(token)["user_id"]
         if settings.REPORTING_USING_GATEKEEPER
         else token.id
     )
-    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
+    uuid_of_pdf = f"{user_id}/{uuid_v4}"
 
     if not data and not settings.REPORTING_USING_GATEKEEPER:
         raise HTTPException(
@@ -89,7 +90,7 @@ async def generate_irrigation_report(
             pdf_file_name=uuid_of_pdf,
         )
 
-        return uuid_of_pdf
+        return PDF(uuid=uuid_v4)
 
     else:
         try:
@@ -99,7 +100,7 @@ async def generate_irrigation_report(
                 pdf_file_name=uuid_of_pdf,
             )
 
-            return uuid_of_pdf
+            return PDF(uuid=uuid_v4)
 
         except JSONDecodeError as e:
             raise HTTPException(
@@ -108,7 +109,7 @@ async def generate_irrigation_report(
             )
 
 
-@router.post("/compost-report/")
+@router.post("/compost-report/", response_model=PDF)
 async def generate_generic_observation_report(
     observation_type_name: str,
     background_tasks: BackgroundTasks,
@@ -126,13 +127,13 @@ async def generate_generic_observation_report(
 
     if observation_type_name == "CropStressIndicator":
         observation_type_name = "Crop Stress Indicator"
-    uuid_of_pdf = str(uuid.uuid4())
+    uuid_v4 = str(uuid.uuid4())
     user_id = (
         decode_jwt_token(token)["user_id"]
         if settings.REPORTING_USING_GATEKEEPER
         else token.id
     )
-    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
+    uuid_of_pdf = f"{user_id}/{uuid_v4}"
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:
@@ -180,8 +181,7 @@ async def generate_generic_observation_report(
             pdf_file_name=uuid_of_pdf,
         )
 
-        return uuid_of_pdf
-
+        return PDF(uuid=uuid_v4)
     else:
         try:
             dt = json.load(data.file)
@@ -194,7 +194,7 @@ async def generate_generic_observation_report(
                 pdf_file_name=uuid_of_pdf,
             )
 
-            return uuid_of_pdf
+            return PDF(uuid=uuid_v4)
 
         except JSONDecodeError as e:
             raise HTTPException(
@@ -203,7 +203,7 @@ async def generate_generic_observation_report(
             )
 
 
-@router.post("/animal-report/")
+@router.post("/animal-report/", response_model=PDF)
 async def generate_animal_report(
     background_tasks: BackgroundTasks,
     token=Depends(deps.get_current_user),
@@ -216,13 +216,13 @@ async def generate_animal_report(
     """
     Generates Animal Report PDF file
     """
-    uuid_of_pdf = str(uuid.uuid4())
+    uuid_v4 = str(uuid.uuid4())
     user_id = (
         decode_jwt_token(token)["user_id"]
         if settings.REPORTING_USING_GATEKEEPER
         else token.id
     )
-    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
+    uuid_of_pdf = f"{user_id}/{uuid_v4}"
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:
@@ -254,7 +254,7 @@ async def generate_animal_report(
             process_animal_data, json_data=json_response, pdf_file_name=uuid_of_pdf
         )
 
-        return uuid_of_pdf
+        return PDF(uuid=uuid_v4)
 
     else:
         try:
@@ -264,7 +264,7 @@ async def generate_animal_report(
                 pdf_file_name=uuid_of_pdf,
             )
 
-            return uuid_of_pdf
+            return PDF(uuid=uuid_v4)
 
         except JSONDecodeError as e:
             raise HTTPException(

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -16,6 +16,7 @@ from pydantic import UUID4
 
 from api import deps
 from core import settings
+from utils import decode_jwt_token
 from utils.animals_report import process_animal_data
 from utils.farm_calendar_report import process_farm_calendar_data
 from utils.irrigation_report import process_irrigation_data
@@ -50,6 +51,12 @@ async def generate_irrigation_report(
 
     """
     uuid_of_pdf = str(uuid.uuid4())
+    user_id = (
+        decode_jwt_token(token)["user_id"]
+        if settings.REPORTING_USING_GATEKEEPER
+        else token.id
+    )
+    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
 
     if not data and not settings.REPORTING_USING_GATEKEEPER:
         raise HTTPException(
@@ -112,6 +119,12 @@ async def generate_generic_observation_report(
     if observation_type_name == "CropStressIndicator":
         observation_type_name = "Crop Stress Indicator"
     uuid_of_pdf = str(uuid.uuid4())
+    user_id = (
+        decode_jwt_token(token)["user_id"]
+        if settings.REPORTING_USING_GATEKEEPER
+        else token.id
+    )
+    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:
@@ -196,6 +209,12 @@ async def generate_animal_report(
     Generates Animal Report PDF file
     """
     uuid_of_pdf = str(uuid.uuid4())
+    user_id = (
+        decode_jwt_token(token)["user_id"]
+        if settings.REPORTING_USING_GATEKEEPER
+        else token.id
+    )
+    uuid_of_pdf = f"{user_id}/{uuid_of_pdf}"
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:

--- a/app/api/api_v1/endpoints/report.py
+++ b/app/api/api_v1/endpoints/report.py
@@ -49,6 +49,7 @@ async def generate_irrigation_report(
     Generates Irrigation Report PDF file
 
     """
+    uuid_of_pdf = str(uuid.uuid4())
 
     if not data and not settings.REPORTING_USING_GATEKEEPER:
         raise HTTPException(
@@ -67,8 +68,6 @@ async def generate_irrigation_report(
         if not farm_calendar_irrigation_response:
             raise HTTPException(status_code=400, detail="No Irrigation data found.")
 
-        uuid_of_pdf = str(uuid.uuid4())
-
         background_tasks.add_task(
             process_irrigation_data,
             json_data=farm_calendar_irrigation_response,
@@ -79,8 +78,6 @@ async def generate_irrigation_report(
 
     else:
         try:
-            uuid_of_pdf = str(uuid.uuid4())
-
             background_tasks.add_task(
                 process_irrigation_data,
                 json_data=json.load(data.file),
@@ -114,6 +111,7 @@ async def generate_generic_observation_report(
 
     if observation_type_name == "CropStressIndicator":
         observation_type_name = "Crop Stress Indicator"
+    uuid_of_pdf = str(uuid.uuid4())
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:
@@ -153,8 +151,6 @@ async def generate_generic_observation_report(
         if not farm_activities:
             raise HTTPException(status_code=400, detail="Farm Activities are empty.")
 
-        uuid_of_pdf = str(uuid.uuid4())
-
         background_tasks.add_task(
             process_farm_calendar_data,
             activity_type_info=observation_type_name,
@@ -168,8 +164,6 @@ async def generate_generic_observation_report(
     else:
         try:
             dt = json.load(data.file)
-
-            uuid_of_pdf = str(uuid.uuid4())
 
             background_tasks.add_task(
                 process_farm_calendar_data,
@@ -201,6 +195,7 @@ async def generate_animal_report(
     """
     Generates Animal Report PDF file
     """
+    uuid_of_pdf = str(uuid.uuid4())
 
     if not data:
         if not settings.REPORTING_USING_GATEKEEPER:
@@ -228,8 +223,6 @@ async def generate_animal_report(
         if not json_response:
             raise HTTPException(status_code=400, detail="No animal data found.")
 
-        uuid_of_pdf = str(uuid.uuid4())
-
         background_tasks.add_task(
             process_animal_data, json_data=json_response, pdf_file_name=uuid_of_pdf
         )
@@ -238,8 +231,6 @@ async def generate_animal_report(
 
     else:
         try:
-            uuid_of_pdf = str(uuid.uuid4())
-
             background_tasks.add_task(
                 process_animal_data,
                 json_data=json.load(data.file),

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
         "animals": "/FarmAnimals/",
     }
 
+    PDF_DIRECTORY: str = "user_reports/"
     SQLALCHEMY_DATABASE_URI: Optional[str] = None
 
     @field_validator("SQLALCHEMY_DATABASE_URI", mode="before")

--- a/app/schemas/animals.py
+++ b/app/schemas/animals.py
@@ -18,7 +18,7 @@ class Animal(BaseModel):
     description: str
     hasAgriParcel: Optional[HasAgriParcel] = None
     sex: int
-    castrated: bool
+    isCastrated: bool = False
     species: str
     breed: str
     birthdate: datetime

--- a/app/schemas/generic.py
+++ b/app/schemas/generic.py
@@ -3,3 +3,7 @@ from pydantic import BaseModel
 
 class Message(BaseModel):
     message: str
+
+
+class PDF(BaseModel):
+    uuid: str

--- a/app/utils/animals_report.py
+++ b/app/utils/animals_report.py
@@ -80,4 +80,5 @@ def process_animal_data(json_data: Union[List[dict], str], pdf_file_name: str):
     animals = parse_animal_data(json_data)
     if not animals:
         return None
-    return create_pdf_from_animals(animals)
+    anima_pdf = create_pdf_from_animals(animals)
+    anima_pdf.output(f"{pdf_file_name}.pdf")

--- a/app/utils/animals_report.py
+++ b/app/utils/animals_report.py
@@ -1,5 +1,7 @@
 from typing import List, Union
-from utils import EX, add_fonts
+
+from core import settings
+from utils import EX, add_fonts, decode_jwt_token
 from schemas.animals import *
 
 
@@ -81,4 +83,5 @@ def process_animal_data(json_data: Union[List[dict], str], pdf_file_name: str):
     if not animals:
         return None
     anima_pdf = create_pdf_from_animals(animals)
-    anima_pdf.output(f"{pdf_file_name}.pdf")
+    pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+    anima_pdf.output(f"{pdf_dir}.pdf")

--- a/app/utils/animals_report.py
+++ b/app/utils/animals_report.py
@@ -73,7 +73,7 @@ def create_pdf_from_animals(animals: List[Animal]):
     return pdf
 
 
-def process_animal_data(json_data: Union[List[dict], str]):
+def process_animal_data(json_data: Union[List[dict], str], pdf_file_name: str):
     """
     Process animal data and generate PDF report
     """

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -160,6 +160,7 @@ def process_farm_calendar_data(
     activity_type_info: str,
     observations: Union[dict, str],
     farm_activities: Union[dict, str],
+    pdf_file_name: str,
 ) -> EX:
     """
     Process farm calendar data and generate PDF report

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -2,6 +2,7 @@ import logging
 from typing import Union
 from fastapi import HTTPException
 
+from core import settings
 from schemas.compost import *
 from utils import EX, add_fonts
 
@@ -161,7 +162,7 @@ def process_farm_calendar_data(
     observations: Union[dict, str],
     farm_activities: Union[dict, str],
     pdf_file_name: str,
-) -> EX:
+) -> None:
     """
     Process farm calendar data and generate PDF report
     """
@@ -173,7 +174,8 @@ def process_farm_calendar_data(
         )
 
         pdf = create_farm_calendar_pdf(calendar_data)
-        return pdf
+        pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+        pdf.output(f"{pdf_dir}.pdf")
 
     except Exception as e:
         raise HTTPException(

--- a/app/utils/farm_calendar_report.py
+++ b/app/utils/farm_calendar_report.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Union
 from fastapi import HTTPException
 
@@ -175,9 +176,10 @@ def process_farm_calendar_data(
 
         pdf = create_farm_calendar_pdf(calendar_data)
         pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+        os.makedirs(os.path.dirname(f"{pdf_dir}.pdf"), exist_ok=True)
         pdf.output(f"{pdf_dir}.pdf")
 
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Error processing farm calendar data: {str(e)}"
+            status_code=400, detail=f"Error processing farm calendar data: {str(e)}"
         )

--- a/app/utils/irrigation_report.py
+++ b/app/utils/irrigation_report.py
@@ -3,6 +3,7 @@ from typing import Union, Optional
 
 from fastapi import HTTPException
 
+from core import settings
 from utils import EX, add_fonts
 from schemas.irrigation import *
 
@@ -118,5 +119,5 @@ def process_irrigation_data(json_data: dict, pdf_file_name: str):
         return None
 
     pdf = create_pdf_from_operations(operations)
-
-    return pdf
+    pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+    pdf.output(f"{pdf_dir}.pdf")

--- a/app/utils/irrigation_report.py
+++ b/app/utils/irrigation_report.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Union, Optional
 
 from fastapi import HTTPException
@@ -109,15 +110,21 @@ def create_pdf_from_operations(operations: List[IrrigationOperation]):
     return pdf
 
 
-def process_irrigation_data(json_data: dict, pdf_file_name: str):
+def process_irrigation_data(json_data: dict, pdf_file_name: str) -> None:
     """
     Process irrigation data and generate PDF report
     """
     operations = parse_irrigation_operations(json_data)
 
     if not operations:
-        return None
+        return
 
-    pdf = create_pdf_from_operations(operations)
+    try:
+        pdf = create_pdf_from_operations(operations)
+    except Exception:
+        raise HTTPException(
+            status_code=400, detail="PDF generation of irrigation report failed."
+        )
     pdf_dir = f"{settings.PDF_DIRECTORY}{pdf_file_name}"
+    os.makedirs(os.path.dirname(f"{pdf_dir}.pdf"), exist_ok=True)
     pdf.output(f"{pdf_dir}.pdf")

--- a/app/utils/irrigation_report.py
+++ b/app/utils/irrigation_report.py
@@ -108,7 +108,7 @@ def create_pdf_from_operations(operations: List[IrrigationOperation]):
     return pdf
 
 
-def process_irrigation_data(json_data: dict):
+def process_irrigation_data(json_data: dict, pdf_file_name: str):
     """
     Process irrigation data and generate PDF report
     """

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,4 +1,6 @@
 import os
+
+import jwt
 from fpdf import FPDF
 
 
@@ -23,3 +25,15 @@ class EX(FPDF):
             keep_aspect_ratio=True,
             x=160,
         )
+
+
+def export_user_id(token: str) -> dict:
+    """
+    Decode JWT token
+
+    :param token: JWT token (str)
+
+    :return: Dictionary with decoded information
+    """
+    decoded = jwt.decode(token, options={"verify_signature": False})
+    return decoded

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -27,7 +27,7 @@ class EX(FPDF):
         )
 
 
-def export_user_id(token: str) -> dict:
+def decode_jwt_token(token: str) -> dict:
     """
     Decode JWT token
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,8 @@ services:
     command: /code/entrypoint.sh ${REPORTING_SERVICE_PORT}
     ports:
       - ${REPORTING_SERVICE_PORT}:${REPORTING_SERVICE_PORT}
+    volumes:
+      - user_reports:/code/app/user_reports
     environment:
       REPORTING_POSTGRES_HOST: ${REPORTING_POSTGRES_HOST}
       REPORTING_POSTGRES_USER: ${REPORTING_POSTGRES_USER}


### PR DESCRIPTION
- Update PDF reports to be retrieved with UUID
- Make response immediately returned with UUID value and use FastAPI background task to generate it in the background
- Add user_reports volume
- Update change of animal data validation
- Add new endpoint for retrieving PDFs
- Create new schema for uuid response
- Update README.md and OpenAPI schema view